### PR TITLE
feat: add shield & update move condition

### DIFF
--- a/Assets/Scripts/PlayerInput.cs
+++ b/Assets/Scripts/PlayerInput.cs
@@ -19,6 +19,9 @@ public class PlayerInput : MonoBehaviour
     internal bool isAlpha5Pressed;
 
     internal bool isMovementSkillPressed;
+    public bool isActionSkillPressed;
+    public bool isActionSkillReleased;
+    public bool isActionSkillHeld;
 
     void Start()
     {
@@ -42,5 +45,8 @@ public class PlayerInput : MonoBehaviour
         isAlpha5Pressed = Input.GetKeyDown(KeyCode.Alpha5);
 
         isMovementSkillPressed = Input.GetKeyDown(KeyCode.LeftShift) || Input.GetKeyDown(KeyCode.RightShift);
+        isActionSkillPressed = Input.GetKeyDown(KeyCode.F);
+        isActionSkillReleased = Input.GetKeyUp(KeyCode.F);
+        isActionSkillHeld = Input.GetKey(KeyCode.F);
     }
 }

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -32,12 +32,15 @@ public class PlayerMovement : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (CanNotMove()) return;
+        if (CanMove())
+        {
+            HandleHorizontalMovement();
+            HandleVerticalMovement();
+        }
 
-        HandleHorizontalMovement();
-        HandleVerticalMovement();
         playerController.playerShape.shape.HandlePassiveSkill();
         playerController.playerShape.shape.HandleMovementSkill();
+        playerController.playerShape.shape.HandleActionSkill();
     }
 
     private void HandleHorizontalMovement()
@@ -136,9 +139,9 @@ public class PlayerMovement : MonoBehaviour
         rb.velocity = new Vector2(rb.velocity.x, rb.velocity.y * jumpDeceleration);
     }
 
-    private bool CanNotMove()
+    public bool CanMove()
     {
-        bool isSkillActive = playerController.playerShape.shape.IsSkillActive();
-        return isSkillActive || isJumpActive;
+        bool isBlockingSkillActive = playerController.playerShape.shape.IsBlockingSkillActive();
+        return !isBlockingSkillActive && !isJumpActive;
     }
 }

--- a/Assets/Scripts/PlayerShape.cs
+++ b/Assets/Scripts/PlayerShape.cs
@@ -16,7 +16,7 @@ public class PlayerShape : MonoBehaviour
 
     void Update()
     {
-        if (shape.IsSkillActive()) return;
+        if (shape.IsBlockingSkillActive()) return;
 
         if (playerController.playerInput.isAlpha1Pressed)
         {

--- a/Assets/Scripts/Shapes/Circle.cs
+++ b/Assets/Scripts/Shapes/Circle.cs
@@ -15,11 +15,7 @@ public class Circle : Shape
 
     public override void HandlePassiveSkill()
     {
-        bool canMove = playerController.playerMovement.CanMove();
-
-        bool isUpPressed = playerController.playerInput.isUpPressed;
-        bool isInAir = playerController.playerMovement.isInAir;
-        if (canMove && isUpPressed && isInAir && doubleJumpUnlocked && !hasDoubleJumped)
+        if (ShouldDoubleJump())
         {
             hasDoubleJumped = true;
             StartCoroutine(playerController.playerMovement.JumpCoroutine());
@@ -50,5 +46,13 @@ public class Circle : Shape
     public override void DestroyShape()
     {
         Destroy(gameObject.GetComponent<Circle>());
+    }
+
+    private bool ShouldDoubleJump()
+    {
+        bool canMove = playerController.playerMovement.CanMove();
+        bool isUpPressed = playerController.playerInput.isUpPressed;
+        bool isInAir = playerController.playerMovement.isInAir;
+        return canMove && isUpPressed && isInAir && doubleJumpUnlocked && !hasDoubleJumped;
     }
 }

--- a/Assets/Scripts/Shapes/Circle.cs
+++ b/Assets/Scripts/Shapes/Circle.cs
@@ -15,9 +15,11 @@ public class Circle : Shape
 
     public override void HandlePassiveSkill()
     {
+        bool canMove = playerController.playerMovement.CanMove();
+
         bool isUpPressed = playerController.playerInput.isUpPressed;
         bool isInAir = playerController.playerMovement.isInAir;
-        if (isUpPressed && isInAir && doubleJumpUnlocked && !hasDoubleJumped)
+        if (canMove && isUpPressed && isInAir && doubleJumpUnlocked && !hasDoubleJumped)
         {
             hasDoubleJumped = true;
             StartCoroutine(playerController.playerMovement.JumpCoroutine());
@@ -36,8 +38,13 @@ public class Circle : Shape
 
     public override void ResetOnCollision()
     {
-        ClearSkills();
         hasDoubleJumped = false;
+    }
+
+    public override bool IsBlockingSkillActive()
+    {
+        // TODO: Implement blocking skill
+        return false;
     }
 
     public override void DestroyShape()

--- a/Assets/Scripts/Shapes/Hexagon.cs
+++ b/Assets/Scripts/Shapes/Hexagon.cs
@@ -27,7 +27,13 @@ public class Hexagon : Shape
 
     public override void ResetOnCollision()
     {
-        ClearSkills();
+        // TODO: Implement reset on collision
+    }
+
+    public override bool IsBlockingSkillActive()
+    {
+        // TODO: Implement blocking skill
+        return false;
     }
 
     public override void DestroyShape()

--- a/Assets/Scripts/Shapes/Pentagon.cs
+++ b/Assets/Scripts/Shapes/Pentagon.cs
@@ -27,7 +27,13 @@ public class Pentagon : Shape
 
     public override void ResetOnCollision()
     {
-        ClearSkills();
+        // TODO: Implement reset on collision
+    }
+
+    public override bool IsBlockingSkillActive()
+    {
+        // TODO: Implement blocking skill
+        return false;
     }
 
     public override void DestroyShape()

--- a/Assets/Scripts/Shapes/Shape.cs
+++ b/Assets/Scripts/Shapes/Shape.cs
@@ -15,34 +15,26 @@ public abstract class Shape : MonoBehaviour
 
     internal ShapeType type;
     internal Sprite sprite;
-
     internal ShapeStats stats;
 
-    internal bool isPassiveSkillActive = false;
-    internal bool isMovementSkillActive = false;
-    internal bool isActionSkillActive = false;
-
+    // Initialize the shape (mandatory to call just after shape creation)
     public abstract void Initialize(PlayerController playerController);
 
+    // Check if the player can use his passive skill and then use it
     public abstract void HandlePassiveSkill();
 
+    // Check if the player can use his movement skill and then use it
     public abstract void HandleMovementSkill();
 
+    // Check if the player can use his action skill and then use it
     public abstract void HandleActionSkill();
 
+    // Reset skills variables on collision with ground or wall
     public abstract void ResetOnCollision();
 
+    // Destroy the current shape component
     public abstract void DestroyShape();
 
-    protected void ClearSkills()
-    {
-        isPassiveSkillActive = false;
-        isMovementSkillActive = false;
-        isActionSkillActive = false;
-    }
-
-    public bool IsSkillActive()
-    {
-        return isPassiveSkillActive || isMovementSkillActive || isActionSkillActive;
-    }
+    // Check if the player is using a blocking skill (impossible to change shape, move and use other skills)
+    public abstract bool IsBlockingSkillActive();
 }

--- a/Assets/Scripts/Shapes/Square.cs
+++ b/Assets/Scripts/Shapes/Square.cs
@@ -5,6 +5,9 @@ public class Square : Shape
 
     private readonly float groundPoundForce = 40f;
 
+    private bool isGroundPoundActive = false;
+    private bool isShieldActive = false;
+
     public override void Initialize(PlayerController playerController)
     {
         this.playerController = playerController;
@@ -14,11 +17,12 @@ public class Square : Shape
 
     public override void HandlePassiveSkill()
     {
+        bool canMove = playerController.playerMovement.CanMove();
         bool isInAir = playerController.playerMovement.isInAir;
         bool isDownHeld = playerController.playerInput.isDownHeld;
-        if (isInAir && isDownHeld)
+
+        if (canMove && isInAir && isDownHeld)
         {
-            isPassiveSkillActive = true;
             GroundPound();
         }
     }
@@ -30,12 +34,32 @@ public class Square : Shape
 
     public override void HandleActionSkill()
     {
-        // TODO: Implement action skill
+        bool canNotMove = !playerController.playerMovement.CanMove();
+        // if the player can't move but not because of the shield, return
+        if (canNotMove && !isShieldActive) return;
+
+        if (playerController.playerInput.isActionSkillHeld && !isShieldActive)
+        {
+            isShieldActive = true;
+            // add shield skill (stats update, invincibility...)
+        }
+
+        if (playerController.playerInput.isActionSkillReleased && isShieldActive)
+        {
+            isShieldActive = false;
+            // remove shield skill
+        }
     }
 
     public override void ResetOnCollision()
     {
-        ClearSkills();
+        isGroundPoundActive = false;
+        isShieldActive = false;
+    }
+
+    public override bool IsBlockingSkillActive()
+    {
+        return isShieldActive || isGroundPoundActive;
     }
 
     public override void DestroyShape()
@@ -45,6 +69,8 @@ public class Square : Shape
 
     private void GroundPound()
     {
+        isGroundPoundActive = true;
+
         Rigidbody2D rb = playerController.rb;
         rb.velocity = new Vector2(rb.velocity.x, -1f * groundPoundForce);
     }

--- a/Assets/Scripts/Shapes/Triangle.cs
+++ b/Assets/Scripts/Shapes/Triangle.cs
@@ -8,6 +8,7 @@ public class Triangle : Shape
     private readonly float dashDuration = 0.15f;
 
     private bool hasDashedInAir = false;
+    private bool isDashActive = false;
 
     public override void Initialize(PlayerController playerController)
     {
@@ -23,7 +24,10 @@ public class Triangle : Shape
 
     public override void HandleMovementSkill()
     {
-        if (playerController.playerInput.isMovementSkillPressed && !isMovementSkillActive && !hasDashedInAir)
+        bool canMove = playerController.playerMovement.CanMove();
+        bool isMovementSkillPressed = playerController.playerInput.isMovementSkillPressed;
+
+        if (canMove && isMovementSkillPressed && !hasDashedInAir)
         {
             StartCoroutine(DashCoroutine());
         }
@@ -36,8 +40,13 @@ public class Triangle : Shape
 
     public override void ResetOnCollision()
     {
-        ClearSkills();
         hasDashedInAir = false;
+        isDashActive = false;
+    }
+
+    public override bool IsBlockingSkillActive()
+    {
+        return isDashActive;
     }
 
     public override void DestroyShape()
@@ -47,7 +56,7 @@ public class Triangle : Shape
 
     private void Dash()
     {
-        isMovementSkillActive = true;
+        isDashActive = true;
 
         // Determine the current horizontal direction the player is facing (either Left or Right)
         Direction horizontalDirection = playerController.playerMovement.direction;
@@ -83,7 +92,7 @@ public class Triangle : Shape
         playerController.trailRenderer.emitting = false;     // Turn off the trail renderer
 
         // Set the movement skill flag to false, indicating that the dash has ended
-        isMovementSkillActive = false;
+        isDashActive = false;
 
         // Check if the player was jumping while dashing, and set a flag if true
         if (playerController.playerMovement.isInAir)


### PR DESCRIPTION
- Ajout des variables pour le skill actif (touche F)
- Modification de la fonction `Update()` de `PlayerMovement`. Avant, si un skill ou un saut était en cours, aucun mouvement, ni skill était possible. Le problème est que le bouclier s'active et se désactive donc il est nécessaire de jouer en continu la fonction d'action pour vérifier le 2ème cas. Les vérifications de mouvement pour les compétences ont donc été déplacées dans les fonctions spécifiques à chaque forme.
- Les variables de la classe `Shape`: `isMovementSkillActive`, etc. ont été supprimés avec la fonction `ClearSkills()` et ont été remplacées par des variables plus précises dans les formes (`isDashActive`) et la fonction abstraite `IsBlockingSkillActive()`. Cette fonction permet de vérifier si une compétence bloquant les mouvements du personnage est en cours. Etant abstraite, cette fonction est définie dans chaque forme.
- Ajout du template de la compétence bouclier. C'est à dire que les mouvements et le changement de forme sont bien bloqués tant qu'on laisse appuyer sur la touche mais c'est tout (pas encore d'augmentation des stats ou invulnérabilité).
- Ajout de commentaires dans la classe `Shape` pour expliquer les fonctions abstraites des formes.